### PR TITLE
Switch deploy workflow trigger from master to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- デフォルトブランチを \`master\` → \`main\` に変更する準備として、deploy ワークフローのトリガーを更新
- このPRをマージ後、GitHub の Settings → Branches で \`master\` を \`main\` にリネーム予定

## Test plan
- [ ] マージ後、\`main\` ブランチへの push でワークフローが正常に動作することを確認