### PR TITLE
Require unconditional reboot after wsl --install in pcenv index

### DIFF
--- a/pcenv/index.md
+++ b/pcenv/index.md
@@ -74,7 +74,7 @@ WSL は以下の手順でインストールする。
     ```
     wsl --install --no-distribution
     ```
-2. 再起動を求められた場合は PC を再起動。再起動後、改めて管理者として Windows Terminal を起動する。
+2. インストール後、PC を再起動する。再起動後、以降の作業のために改めて管理者として Windows Terminal を起動する。
 
 ## 3.2 Mac : Homebrew
 


### PR DESCRIPTION
## Summary
- 初期化した実機で確認したところ、\`wsl --install --no-distribution\` の後は必ず PC 再起動が必要だった
- section 3.1 の手順を「再起動を求められた場合は」という条件付き表現から、「PC を再起動する」という常時必須の表現に変更
- 併せて再起動後の動線も明示

## Test plan
- [ ] PR プレビューで section 3.1 の表記が更新されているか確認