### PR TITLE
Add Ubuntu install step after WSL reboot in pcenv index

### DIFF
--- a/pcenv/index.md
+++ b/pcenv/index.md
@@ -75,6 +75,11 @@ WSL は以下の手順でインストールする。
     wsl --install --no-distribution
     ```
 2. インストール後、PC を再起動する。再起動後、以降の作業のために改めて管理者として Windows Terminal を起動する。
+3. Ubuntu ディストリビューションをインストールする。管理者として起動した Windows Terminal で以下を実行
+    ```
+    wsl --install -d Ubuntu
+    ```
+4. インストール完了後、Ubuntu のウィンドウが開き、初期設定が始まる。画面の指示に従って Linux 用のユーザー名とパスワードを設定する。
 
 ## 3.2 Mac : Homebrew
 


### PR DESCRIPTION
## Summary
- WSL のインストール（`wsl --install --no-distribution`）と再起動の後に、Ubuntu ディストリビューションを `wsl --install -d Ubuntu` で導入する手順を section 3.1 に追加
- 一括導入用 \`pcenv-setup-all.bat\` の流れ（WSL 有効化 → 再起動 → Ubuntu 追加）と整合
- Ubuntu の初期設定（Linux 用ユーザー名／パスワード）の説明も追記

## Test plan
- [ ] PR プレビューで section 3.1 の表記を確認
- [ ] 初期化した実機で手順通りに進めて、Ubuntu が正常に導入され、初期設定に入れること