### PR TITLE
Align pcenv setup scripts with new index.md flow

### DIFF
--- a/pcenv/pcenv-setup-all.bat
+++ b/pcenv/pcenv-setup-all.bat
@@ -19,29 +19,21 @@ if errorlevel 1 (
 
 cd /d "%~dp0"
 
-:: Enable WSL if not already functional
+:: Enable WSL if not already functional. Reboot is required after the
+:: kernel is installed; once enabled, re-run this batch to continue.
 wsl --status >nul 2>&1
 if errorlevel 1 (
     echo Enable WSL
     wsl --install --no-distribution
     if errorlevel 1 goto wsl_error
-
-    :: After install, check again. If still not functional, reboot is required.
-    wsl --status >nul 2>&1
-    if errorlevel 1 (
-        echo.
-        echo ======================================================
-        echo  WSL has been enabled. Restart your PC,
-        echo  then run this batch again.
-        echo ======================================================
-        pause
-        exit /b 0
-    )
+    echo.
+    echo ======================================================
+    echo  WSL has been enabled. Restart your PC,
+    echo  then run this batch again.
+    echo ======================================================
+    pause
+    exit /b 0
 )
-
-echo Install Visual Studio Code
-winget install -e --id Microsoft.VisualStudioCode --source winget --accept-package-agreements --accept-source-agreements
-if errorlevel 1 goto error
 
 echo Install Git with custom options for Visual Studio Code, External OpenSSH, and LF line endings
 winget install --id Git.Git -e --override "/VERYSILENT /NORESTART /NOCANCEL /SP- /o:EditorOption=VisualStudioCode /o:SSHOption=ExternalOpenSSH /o:CRLFOption=LFOnly" --accept-package-agreements --accept-source-agreements
@@ -51,8 +43,12 @@ echo Install GitHub Desktop
 winget install -e --id GitHub.GitHubDesktop --accept-package-agreements --accept-source-agreements
 if errorlevel 1 goto error
 
-echo Install Ubuntu distribution for WSL
-wsl --install -d Ubuntu
+echo Install Docker Desktop
+winget install -e --id Docker.DockerDesktop --source winget --accept-package-agreements --accept-source-agreements
+if errorlevel 1 goto error
+
+echo Install Visual Studio Code
+winget install -e --id Microsoft.VisualStudioCode --source winget --accept-package-agreements --accept-source-agreements
 if errorlevel 1 goto error
 
 set "CODE=%LOCALAPPDATA%\Programs\Microsoft VS Code\bin\code.cmd"
@@ -71,8 +67,8 @@ if errorlevel 1 goto error
 "%CODE%" --install-extension MS-CEINTL.vscode-language-pack-ja
 if errorlevel 1 goto error
 
-echo Install Docker Desktop
-winget install -e --id Docker.DockerDesktop --source winget --accept-package-agreements --accept-source-agreements
+echo Install Ubuntu distribution for WSL
+wsl --install -d Ubuntu
 if errorlevel 1 goto error
 
 echo.

--- a/pcenv/pcenv-setup-all.sh
+++ b/pcenv/pcenv-setup-all.sh
@@ -26,14 +26,17 @@ if [[ -z "$BREW_BIN" ]]; then
 fi
 eval "$("$BREW_BIN" shellenv)"
 
-echo "Install Visual Studio Code"
-brew install --cask visual-studio-code
-
 echo "Install Git"
 brew install git
 
 echo "Install GitHub Desktop"
 brew install --cask github
+
+echo "Install Docker Desktop"
+brew install --cask docker
+
+echo "Install Visual Studio Code"
+brew install --cask visual-studio-code
 
 echo "Install VS Code extensions"
 CODE="$(command -v code || true)"
@@ -48,9 +51,6 @@ fi
 "$CODE" --install-extension ms-vscode-remote.vscode-remote-extensionpack
 "$CODE" --install-extension ms-azuretools.vscode-docker
 "$CODE" --install-extension MS-CEINTL.vscode-language-pack-ja
-
-echo "Install Docker Desktop"
-brew install --cask docker
 
 echo ""
 echo "======================================================"

--- a/pcenv/pcenv-setup-wsl.bat
+++ b/pcenv/pcenv-setup-wsl.bat
@@ -1,0 +1,38 @@
+@echo off
+
+:: Self-elevate to administrator if not already
+fsutil dirty query %systemdrive% >nul 2>&1
+if errorlevel 1 (
+    echo This batch requires administrator privileges.
+    echo Click "Yes" on the UAC dialog.
+    set "BAT_PATH=%~f0"
+    powershell -NoProfile -Command "Start-Process -FilePath $env:BAT_PATH -Verb RunAs"
+    if errorlevel 1 (
+        echo.
+        echo ERROR: Failed to elevate to administrator.
+        echo Cancel was clicked on the UAC dialog or PowerShell is unavailable.
+        pause
+        exit /b 1
+    )
+    exit /b
+)
+
+cd /d "%~dp0"
+
+wsl --install --no-distribution
+if errorlevel 1 (
+    echo.
+    echo ======================================================
+    echo  WSL installation failed.
+    echo  Check the error and try again.
+    echo ======================================================
+    pause
+    exit /b 1
+)
+
+echo.
+echo ======================================================
+echo  WSL has been enabled. Restart your PC
+echo  before continuing with the setup.
+echo ======================================================
+pause


### PR DESCRIPTION
## Summary
- 一括導入用スクリプトを最新の \`pcenv/index.md\` の順序に合わせて再構成
  - install 順を Git → GitHub Desktop → Docker Desktop → VS Code に変更
  - VS Code 拡張機能のインストール後に Ubuntu をインストールする並びに変更
- \`pcenv-setup-all.bat\`
  - WSL 有効化後の「もう一度 wsl --status を確認」ロジックを廃止し、再起動を求めて即終了する形に簡略化（再起動が常に必要なため）
- \`pcenv-setup-wsl.bat\` を再追加
  - WSL のみインストールしたいユーザー向けの専用バッチ
  - self-elevation + \`wsl --install --no-distribution\` + 再起動メッセージ

## Test plan
- [ ] PR プレビューで関連ファイルの変更を確認
- [ ] WSL 未有効の Windows 11 で \`pcenv-setup-all.bat\` をダブルクリック → UAC 昇格 → WSL 有効化 → メッセージに従って再起動 → 再実行で完了
- [ ] WSL 有効済みの Windows 11 で \`pcenv-setup-all.bat\` を実行 → 順序通りインストール → Setup completed メッセージ
- [ ] \`pcenv-setup-wsl.bat\` を単独実行 → UAC 昇格 → WSL 有効化 → 再起動メッセージ
- [ ] Mac で \`pcenv-setup-all.sh\` 実行 → 新順序でインストール完了