### PR TITLE
Drop self-elevation from pcenv-setup-stage2.bat

### DIFF
--- a/pcenv/pcenv-setup-all.md
+++ b/pcenv/pcenv-setup-all.md
@@ -15,7 +15,7 @@ github:
 2. **pcenv-setup-stage1.bat** をダブルクリックして実行（UAC ダイアログで `はい` をクリック）
 3. インストール完了のメッセージが表示されたら、PC を再起動
 4. 再起動後、[pcenv-setup-stage2.bat](pcenv-setup-stage2.bat) をダウンロード
-5. **pcenv-setup-stage2.bat** をダブルクリックして実行（UAC ダイアログで `はい` をクリック）
+5. **pcenv-setup-stage2.bat** をダブルクリックして実行
 6. 完了メッセージが表示されたらインストール終了
 
 ## 1.2 Mac の場合

--- a/pcenv/pcenv-setup-stage2.bat
+++ b/pcenv/pcenv-setup-stage2.bat
@@ -1,21 +1,8 @@
 @echo off
 
-:: Self-elevate to administrator if not already
-fsutil dirty query %systemdrive% >nul 2>&1
-if errorlevel 1 (
-    echo This batch requires administrator privileges.
-    echo Click "Yes" on the UAC dialog.
-    set "BAT_PATH=%~f0"
-    powershell -NoProfile -Command "try { Start-Process -FilePath $env:BAT_PATH -Verb RunAs -ErrorAction Stop } catch { exit 1 }"
-    if errorlevel 1 (
-        echo.
-        echo ERROR: Failed to elevate to administrator.
-        echo Cancel was clicked on the UAC dialog or PowerShell is unavailable.
-        pause
-        exit /b 1
-    )
-    exit /b
-)
+:: Both wsl --install -d Ubuntu (after WSL is already enabled) and
+:: VS Code extension installs are user-level operations, so this stage
+:: does not require administrator privileges.
 
 cd /d "%~dp0"
 


### PR DESCRIPTION
## Summary
- \`pcenv-setup-stage2.bat\` から self-elevation 処理を削除
- stage2 で実行する操作はいずれもユーザーレベル：
  - \`wsl --install -d Ubuntu\`: WSL 有効化済み環境での distro 追加
  - \`code --install-extension ...\`: ユーザープロファイルへの拡張機能インストール
- それに合わせて \`pcenv-setup-all.md\` の手順から「UAC ダイアログで はい」の記述を削除

## メリット
- UAC ダイアログ表示が 1 回減る
- bat のロジックがシンプルに
- stage2 が「軽い後処理」という位置付けが明確になる

## Test plan
- [ ] PR プレビューで \`pcenv-setup-all.md\` の表示を確認
- [ ] stage1 完了 → 再起動 → 非管理者の Windows Terminal で stage2.bat をダブルクリック → Ubuntu と拡張機能が問題なくインストールされる