### PR TITLE
Download both stage bats up front in pcenv install guide

### DIFF
--- a/pcenv/pcenv-setup-all.md
+++ b/pcenv/pcenv-setup-all.md
@@ -11,12 +11,11 @@ github:
 
 ## 1.1 Windows の場合
 
-1. [pcenv-setup-stage1.bat](pcenv-setup-stage1.bat) をダウンロード
+1. [pcenv-setup-stage1.bat](pcenv-setup-stage1.bat) と [pcenv-setup-stage2.bat](pcenv-setup-stage2.bat) をダウンロード
 2. **pcenv-setup-stage1.bat** をダブルクリックして実行（UAC ダイアログで `はい` をクリック）
 3. インストール完了のメッセージが表示されたら、PC を再起動
-4. 再起動後、[pcenv-setup-stage2.bat](pcenv-setup-stage2.bat) をダウンロード
-5. **pcenv-setup-stage2.bat** をダブルクリックして実行
-6. 完了メッセージが表示されたらインストール終了
+4. 再起動後、**pcenv-setup-stage2.bat** をダブルクリックして実行
+5. 完了メッセージが表示されたらインストール終了
 
 ## 1.2 Mac の場合
 


### PR DESCRIPTION
## Summary
- \`pcenv-setup-all.md\` の Windows 手順を「最初に stage1 と stage2 を **両方ダウンロード**」する形に戻す
- 以前は再起動後に stage2 をダウンロードする流れにしたが、実際にやってみると再起動後にブラウザを開いてサイトに戻る手間がかかり、UX 的にデメリットが大きかった

## なぜ戻すか
- 再起動後にブラウザでサイトに戻るのは思った以上に手間（再起動でタブも閉じる）
- ファイル名 \`stage1\` / \`stage2\` で順序が明確なので、stage2 を間違って先に実行するリスクは低い
- ダウンロードフォルダに 2 つ並んでいる方が「次は stage2」と分かりやすい

## Test plan
- [ ] PR プレビューで Windows 手順の表示を確認