### PR TITLE
Note Docker Desktop WSL 2 checkbox in pcenv setup

### DIFF
--- a/pcenv/index.md
+++ b/pcenv/index.md
@@ -100,7 +100,7 @@ WSL を完全に有効化するには PC の再起動が必要だが、後の Do
 
 - 管理者として起動した Windows Terminal で以下を実行
   ```
-  winget install --id Git.Git -e --override "/VERYSILENT /NORESTART /NOCANCEL /SP- /o:EditorOption=VisualStudioCode /o:SSHOption=ExternalOpenSSH /o:CRLFOption=LFOnly"
+  winget install --id Git.Git -e --source winget --override "/VERYSILENT /NORESTART /NOCANCEL /SP- /o:EditorOption=VisualStudioCode /o:SSHOption=ExternalOpenSSH /o:CRLFOption=LFOnly"
   ```
 
 ## 4.2 Mac の場合
@@ -152,6 +152,7 @@ Docker Desktop はコンテナ実行環境である。
   ```
   winget install -e --id Docker.DockerDesktop --source winget
   ```
+- インストーラの画面で **Use WSL 2 instead of Hyper-V (recommended)** にチェックが入っていることを確認する。チェックが外れていたら入れてから次に進む。
 
 ## 7.2 Mac の場合
 

--- a/pcenv/pcenv-setup-all.md
+++ b/pcenv/pcenv-setup-all.md
@@ -13,9 +13,10 @@ github:
 
 1. [pcenv-setup-stage1.bat](pcenv-setup-stage1.bat) と [pcenv-setup-stage2.bat](pcenv-setup-stage2.bat) をダウンロード
 2. **pcenv-setup-stage1.bat** をダブルクリックして実行（UAC ダイアログで `はい` をクリック）
-3. インストール完了のメッセージが表示されたら、PC を再起動
-4. 再起動後、**pcenv-setup-stage2.bat** をダブルクリックして実行
-5. 完了メッセージが表示されたらインストール終了
+3. 途中で Docker Desktop のインストーラが起動したら、**Use WSL 2 instead of Hyper-V (recommended)** にチェックが入っていることを確認する。チェックが外れていたら入れてから次に進む。
+4. インストール完了のメッセージが表示されたら、PC を再起動
+5. 再起動後、**pcenv-setup-stage2.bat** をダブルクリックして実行
+6. 完了メッセージが表示されたらインストール終了
 
 ## 1.2 Mac の場合
 

--- a/pcenv/pcenv-setup-stage1.bat
+++ b/pcenv/pcenv-setup-stage1.bat
@@ -39,6 +39,13 @@ winget install -e --id GitHub.GitHubDesktop --accept-package-agreements --accept
 if errorlevel 1 goto error
 
 echo Install Docker Desktop
+echo.
+echo ******************************************************
+echo  IMPORTANT: When the Docker Desktop installer opens,
+echo  make sure "Use WSL 2 instead of Hyper-V (recommended)"
+echo  is CHECKED. If it is not, check it before continuing.
+echo ******************************************************
+echo.
 winget install -e --id Docker.DockerDesktop --source winget --accept-package-agreements --accept-source-agreements
 if errorlevel 1 goto error
 


### PR DESCRIPTION
## Summary
- Docker Desktop インストーラの **Use WSL 2 instead of Hyper-V (recommended)** チェックボックスについて 3 か所で注意喚起
  - \`pcenv-setup-stage1.bat\`: Docker Desktop インストーラ起動の直前に目立つメッセージを echo（cmd.exe の codepage 問題で日本語化は見送り、英語のままにしている）
  - \`pcenv/index.md\` 7.1: チェックボックスについての箇条書きを追加
  - \`pcenv-setup-all.md\`: 一括導入手順にもチェックボックスの確認ステップを追加

## 背景
- 実機検証で stage1.bat 実行中に Docker Desktop インストーラが立ち上がった際、上記チェックボックスが外れた状態で起動するケースを確認
- WSL 2 バックエンドが Windows 11 での推奨構成なので、確実にチェックされるよう案内

## Test plan
- [ ] PR プレビューで index.md / pcenv-setup-all.md の表示を確認
- [ ] stage1.bat 実行時に Docker Desktop インストーラ起動前のメッセージが表示されること