### PR TITLE
Add wsl --update before Ubuntu install in stage2 (resolve #43)

### DIFF
--- a/pcenv/index.md
+++ b/pcenv/index.md
@@ -208,8 +208,12 @@ code --install-extension MS-CEINTL.vscode-language-pack-ja
 
 WSL に Ubuntu ディストリビューションをインストールする。
 
-1. 管理者として起動した Windows Terminal で以下を実行
+1. 管理者として起動した Windows Terminal で以下を実行し、WSL を最新版に更新する
+    ```
+    wsl --update
+    ```
+2. 続けて Ubuntu をインストールする
     ```
     wsl --install -d Ubuntu
     ```
-2. インストール完了後、Ubuntu のウィンドウが開き、初期設定が始まる。画面の指示に従って Linux 用のユーザー名とパスワードを設定する。
+3. インストール完了後、Ubuntu のウィンドウが開き、初期設定が始まる。画面の指示に従って Linux 用のユーザー名とパスワードを設定する。

--- a/pcenv/pcenv-setup-stage2.bat
+++ b/pcenv/pcenv-setup-stage2.bat
@@ -38,6 +38,10 @@ echo  window to finish.
 echo ======================================================
 pause
 
+echo Update WSL to the latest version
+wsl --update
+if errorlevel 1 goto error
+
 echo Install Ubuntu distribution for WSL
 wsl --install -d Ubuntu
 if errorlevel 1 goto error


### PR DESCRIPTION
## Summary
- stage2.bat の \`wsl --install -d Ubuntu\` 直前に \`wsl --update\` を追加（errorlevel チェック付き）
- pcenv/index.md 9.3 章にも同じ \`wsl --update\` ステップを追記し、手動手順と整合
- resolve #43

## 背景
実機検証で、stage1 + 再起動後の stage2 実行中に Windows が「wsl --update が必要」というメッセージを出すケースが確認された。\`wsl --install --no-distribution\` を stage1 で実行しても WSL ストアアプリ／カーネルが古いまま残ることがあり、Ubuntu インストール前に明示的に \`wsl --update\` を入れる必要がある。

Issue #43 の起票時点では「stage1 のどこかで」と想定していたが、検証結果により stage2（Ubuntu インストール直前）が適切と判断した。

## Test plan
- [ ] Windows 11 PC で stage1 → 再起動 → stage2 を流し、\`wsl --update\` ステップが正常終了することを確認
- [ ] \`wsl --update\` 後に \`wsl --install -d Ubuntu\` が成功することを確認
- [ ] PR Preview で 9.3 章の手順表示が崩れていないことを確認