### PR TITLE
Revise section 9.3 title and Ubuntu shell exit guidance (resolve #47)

### DIFF
--- a/pcenv/index.md
+++ b/pcenv/index.md
@@ -207,9 +207,9 @@ code --install-extension ms-azuretools.vscode-docker
 code --install-extension MS-CEINTL.vscode-language-pack-ja
 ```
 
-## 9.3 Ubuntu のインストール（Windows のみ）
+## 9.3 WSL の更新と Ubuntu のインストール（Windows のみ）
 
-WSL に Ubuntu ディストリビューションをインストールする。
+WSL を最新版に更新したうえで、Ubuntu ディストリビューションをインストールする。
 
 1. 管理者として起動した Windows Terminal で以下を実行し、WSL を最新版に更新する
     ```
@@ -219,4 +219,4 @@ WSL に Ubuntu ディストリビューションをインストールする。
     ```
     wsl --install -d Ubuntu
     ```
-3. インストール完了後、Ubuntu のウィンドウが開き、初期設定が始まる。画面の指示に従って Linux 用のユーザー名とパスワードを設定する。
+3. インストール完了後、Ubuntu のウィンドウが開き、初期設定が始まる。画面の指示に従って Linux 用のユーザー名とパスワードを設定する。設定が終わったら `exit` と入力するか、Ubuntu のウィンドウを閉じる。


### PR DESCRIPTION
## Summary
- 9.3 のタイトルを「Ubuntu のインストール」→「**WSL の更新と Ubuntu のインストール**」に変更し、\`wsl --update\` ステップを含む実態と整合させた
- 導入文を「WSL を最新版に更新したうえで、Ubuntu ディストリビューションをインストールする。」に書き直し
- 手順 3 末尾に「設定が終わったら \`exit\` と入力するか、Ubuntu のウィンドウを閉じる」を追記し、stage2.bat の終了案内と整合
- resolve #47

## 検討から外したもの
- \`wsl --update\` の必要理由の追記: 今回は見送り（必要なら別 Issue 化）
- wsl --update を独立章として分離する案: stage2.bat と手動手順の流れがどちらも連続実行なので、9.3 一本にまとめるほうが自然

## Test plan
- [ ] PR Preview で 9.3 の見出しが「9.3 WSL の更新と Ubuntu のインストール（Windows のみ）」になっていることを確認
- [ ] 導入文と手順 3 末尾の追記が崩れずに表示されることを確認