### PR TITLE
Move Japanese language pack install to manual GUI step (resolve #44)

### DIFF
--- a/pcenv/index.md
+++ b/pcenv/index.md
@@ -197,15 +197,23 @@ Visual Studio Code(以下 VSCode) は汎用エディタである。
 
 - リモート開発用拡張パック (Dev Containers / WSL / SSH)
 - Docker 拡張
-- 日本語化拡張
 
 9.1 で起動した Windows Terminal / ターミナル で以下を実行する。
 
 ```
 code --install-extension ms-vscode-remote.vscode-remote-extensionpack
 code --install-extension ms-azuretools.vscode-docker
-code --install-extension MS-CEINTL.vscode-language-pack-ja
 ```
+
+### 9.2.1 日本語化拡張のインストール
+
+日本語化拡張 (Japanese Language Pack) は、コマンドラインからインストールすると VS Code の表示言語が切り替わらないため、VS Code を起動して GUI 経由でインストールする。
+
+1. VS Code を起動する（Windows Terminal / ターミナルで `code` と入力するか、アプリ一覧から起動）
+2. 左サイドバーの **Extensions** アイコン（四角が 4 つ並んだアイコン）をクリック
+3. 検索欄に `Japanese Language Pack` と入力
+4. **Japanese Language Pack for Visual Studio Code** を選択し、**Install** をクリック
+5. インストール完了後、右下に表示される **Change Display Language and Restart** をクリックし、VS Code を再起動する
 
 ## 9.3 WSL の更新と Ubuntu のインストール（Windows のみ）
 

--- a/pcenv/pcenv-setup-all.md
+++ b/pcenv/pcenv-setup-all.md
@@ -27,3 +27,13 @@ github:
     ```
     bash pcenv-setup-all.sh
     ```
+
+## 1.3 仕上げ: VS Code の日本語化拡張をインストール
+
+Windows / Mac とも、上記スクリプト実行後に VS Code の日本語化拡張を GUI からインストールする。コマンドラインからインストールすると表示言語が切り替わらないため、この手順は手動で行う。
+
+1. VS Code を起動する（Windows Terminal / ターミナルで `code` と入力するか、アプリ一覧から起動）
+2. 左サイドバーの **Extensions** アイコン（四角が 4 つ並んだアイコン）をクリック
+3. 検索欄に `Japanese Language Pack` と入力
+4. **Japanese Language Pack for Visual Studio Code** を選択し、**Install** をクリック
+5. インストール完了後、右下に表示される **Change Display Language and Restart** をクリックし、VS Code を再起動する

--- a/pcenv/pcenv-setup-all.sh
+++ b/pcenv/pcenv-setup-all.sh
@@ -53,7 +53,6 @@ if [[ -z "$CODE_BIN" ]]; then
 fi
 "$CODE_BIN" --install-extension ms-vscode-remote.vscode-remote-extensionpack
 "$CODE_BIN" --install-extension ms-azuretools.vscode-docker
-"$CODE_BIN" --install-extension MS-CEINTL.vscode-language-pack-ja
 
 echo ""
 echo "======================================================"

--- a/pcenv/pcenv-setup-stage2.bat
+++ b/pcenv/pcenv-setup-stage2.bat
@@ -22,8 +22,6 @@ call code --install-extension ms-vscode-remote.vscode-remote-extensionpack
 if errorlevel 1 goto error
 call code --install-extension ms-azuretools.vscode-docker
 if errorlevel 1 goto error
-call code --install-extension MS-CEINTL.vscode-language-pack-ja
-if errorlevel 1 goto error
 
 echo.
 echo ======================================================


### PR DESCRIPTION
## Summary
- \`MS-CEINTL.vscode-language-pack-ja\` の自動インストールを stage2.bat / pcenv-setup-all.sh から削除
- 日本語化拡張は VS Code の Extensions パネルから手動インストールするように、index.md 9.2.1 と pcenv-setup-all.md 1.3 に手順を追加
- resolve #44

## 背景
\`code --install-extension MS-CEINTL.vscode-language-pack-ja\` で導入しても \`locale.json\` が更新されないため、初回起動時に VS Code が英語のまま表示される。GUI インストール時に出る **Change Display Language and Restart** ダイアログを経由しないと自動切替されない。

Issue #44 で挙げた 3 案のうち、**案 B（手動 GUI インストール）** を採用。VS Code 標準フローに乗るので、Jekyll/Cayman のような外部要因変化に耐性がある。

## Test plan
- [ ] PR Preview で 9.2 / 9.2.1 / 1.3 章の表示が崩れていないことを確認
- [ ] stage2.bat 実行時に日本語拡張が CLI 経由でインストールされなくなったことを確認（実機）
- [ ] 9.2.1 / 1.3 章の手順どおりに GUI からインストールして VS Code が日本語化されることを確認（実機）